### PR TITLE
Add number of messages delete to scale down metric

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+autoscaling module:
+
+*   This release adds NumberOfMessageDeleted to SQS scale down metric.

--- a/autoscaling/main.tf
+++ b/autoscaling/main.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_low" {
 
   metric_query {
     id          = "e1"
-    expression  = "m1+m2"
+    expression  = "m1+m2+m3"
     label       = "ApproximateNumberOfMessagesTotal"
     return_data = "true"
   }
@@ -58,6 +58,21 @@ resource "aws_cloudwatch_metric_alarm" "queue_low" {
 
     metric {
       metric_name = "ApproximateNumberOfMessagesNotVisible"
+      namespace   = "AWS/SQS"
+      period      = "60"
+      stat        = "Sum"
+
+      dimensions = {
+        QueueName = var.queue_name
+      }
+    }
+  }
+
+  metric_query {
+    id = "m3"
+
+    metric {
+      metric_name = "NumberOfMessagesDeleted"
       namespace   = "AWS/SQS"
       period      = "60"
       stat        = "Sum"


### PR DESCRIPTION
I noticed running a reindex in the catalogue pipeline that when services scale up and reach a point where they can process messages as fast as they are published on the queue, they were scaled down by the autoscaling policy despite not being idle.


Looking at the alarm metrics for scaling down I noticed that for services that process messages very quickly (like most catalogue services), once they are scaled up to read messages as fast as they're published ApproximateNumberOfMessagesVisible and ApproximateNumberOfMessagesNotVisible can both zero even though they are working.

 
As services delete messages from the queue when they process them successfully, for services that process messages quickly, NumberOfMessagesDeleted is a better metric to figure out if a service is idle or not.