### PR TITLE
Make DLQ alarm optional #5777

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ WORKDIR /workdir
 
 ADD . /workdir
 
-RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common wget gnupg
 
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
-RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-RUN apt-get update && apt-get install -y terraform
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+RUN apt update && apt install -y terraform
+
+RUN git config --global --add safe.directory /workdir
 
 ENTRYPOINT ["/workdir/scripts/tooling.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ ADD . /workdir
 
 RUN apt-get update && apt-get install -y software-properties-common
 
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
-RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-RUN apt-get update && apt-get install -y terraform
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+RUN apt update && apt install -y terraform
+
+RUN git config --global --add safe.directory /workdir
 
 ENTRYPOINT ["/workdir/scripts/tooling.py"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ That includes:
 
 *   An SQS queue
 *   A dead letter queue (DLQ), which receives any failed messages from the original queue
-*   A CloudWatch alarm that raises when there are messages on the DLQ
+*   An optional CloudWatch alarm that raises when there are messages on the DLQ
 *   An IAM policy that lets you read from the queue
 *   Subscriptions from SNS topics to the queue
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Make the DLQ alarm optional by allowing a `null` value for the `alarm_topic_arn` variable.

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
+  count = var.alarm_topic_arn != null ? 1 : 0
+
   alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -38,7 +38,8 @@ variable "max_receive_count" {
 }
 
 variable "alarm_topic_arn" {
-  description = "ARN of the topic where to send notification for DLQs not being empty"
+  description = "ARN of the topic where to send notification for DLQs not being empty. If null, no alarm will be created."
+  default = null
 }
 
 variable "fifo_queue" {

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -39,7 +39,7 @@ variable "max_receive_count" {
 
 variable "alarm_topic_arn" {
   description = "ARN of the topic where to send notification for DLQs not being empty. If null, no alarm will be created."
-  default = null
+  default     = null
 }
 
 variable "fifo_queue" {


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/5777

Make the DLQ alarm optional by allowing a `null` value for the `alarm_topic_arn` variable.

## How to test

Use the updated version of the module to create a new SQS queue or modify an existing SQS queue. If the `alarm_topic_arn` variable is left undefined, the DLQ should not have an alarm associated with it.  

## How can we measure success?

This change should allow us to remove existing DLQ alarms from all catalogue services.

## Have we considered potential risks?

I can't think of any risks. This change will not automatically affect any existing instances of this module because all current instances specify a non-null value for the `alarm_topic_arn` variable.
