### PR TITLE
Add queue alarm on message age

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,10 +6,12 @@ This is useful for monitoring the health of the queue and ensuring that messages
 
 Adds the variables:
 
-- `dlq_alarm_topic_arn` - The ARN of the SNS topic to send DLQ alarm notifications to
-- `main_q_age_alarm_topic_arn` - The ARN of the SNS topic to send main queue age alarm notifications to
+- `dlq_alarm_action_arns` - The ARNs of the resources to send DLQ alarm notifications to
+- `main_q_age_alarm_action_arns` - The ARN of the resources to send main queue age alarm notifications to
 - `max_age_in_hours` - The maximum age of a message in the main queue before the alarm triggers
 - `queue_age_alarm_name_suffix` - The suffix to append to the age alarm name, used to allow EventBridge to filter on the alarm name
 - `dlq_not_empty_alarm_name_suffix` - The suffix to append to the dlq not empty alarm name, used to allow EventBridge to filter on the alarm name
+- `enable_dlq_not_empty_alarm` - Whether to enable the DLQ not empty alarm (default: `false`), overridden if `dlq_alarm_action_arns` is not empty
+- `enable_main_q_age_alarm` - Whether to enable the main queue age alarm (default: `false`), overridden if `main_q_age_alarm_action_arns` is not empty
 
-We deprecate the `alarm_topic_arn` variable in favour of the new `dlq_alarm_topic_arn` and `main_q_age_alarm_topic_arn` variables.
+We deprecate the `alarm_topic_arn` variable in favour of the new `dlq_alarm_action_arns` and `main_q_age_alarm_action_arns` variables.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This change adds a main queue alarm that triggers when the main queue has messages older than a certain age. 
+
+This is useful for monitoring the health of the queue and ensuring that messages are being processed in a timely manner.
+
+Adds the variables:
+
+- `dlq_alarm_topic_arn` - The ARN of the SNS topic to send DLQ alarm notifications to
+- `main_q_age_alarm_topic_arn` - The ARN of the SNS topic to send main queue age alarm notifications to
+- `max_age_in_hours` - The maximum age of a message in the main queue before the alarm triggers
+- `queue_age_alarm_name_suffix` - The suffix to append to the age alarm name, used to allow EventBridge to filter on the alarm name
+- `dlq_not_empty_alarm_name_suffix` - The suffix to append to the dlq not empty alarm name, used to allow EventBridge to filter on the alarm name
+
+We deprecate the `alarm_topic_arn` variable in favour of the new `dlq_alarm_topic_arn` and `main_q_age_alarm_topic_arn` variables.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,8 +9,6 @@ Adds the variables:
 - `dlq_alarm_action_arns` - The ARNs of the resources to send DLQ alarm notifications to
 - `main_q_age_alarm_action_arns` - The ARN of the resources to send main queue age alarm notifications to
 - `max_age_in_hours` - The maximum age of a message in the main queue before the alarm triggers
-- `queue_age_alarm_name_suffix` - The suffix to append to the age alarm name, used to allow EventBridge to filter on the alarm name
-- `dlq_not_empty_alarm_name_suffix` - The suffix to append to the dlq not empty alarm name, used to allow EventBridge to filter on the alarm name
 - `enable_dlq_not_empty_alarm` - Whether to enable the DLQ not empty alarm (default: `false`), overridden if `dlq_alarm_action_arns` is not empty
 - `enable_main_q_age_alarm` - Whether to enable the main queue age alarm (default: `false`), overridden if `main_q_age_alarm_action_arns` is not empty
 

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -2,7 +2,7 @@ locals {
   max_age_in_seconds = var.max_age_in_hours * 3600
 
   # Allows for deprecation of alarm_topic_arn in favor of dlq_alarm_topic_arn
-  alarm_topic_arn_safe = var.alarm_topic_arn != null ? [var.alarm_topic_arn] : []
+  alarm_topic_arn_safe  = var.alarm_topic_arn != null ? [var.alarm_topic_arn] : []
   dlq_alarm_action_arns = var.dlq_alarm_action_arns != [] ? var.dlq_alarm_action_arns : local.alarm_topic_arn_safe
 
   # Name suffix allows for EventBridge rules to pick up alarms using wildcard
@@ -25,6 +25,8 @@ resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
   threshold           = 0
   statistic           = "Average"
 
+  alarm_description = "Alarm if the DLQ is not empty"
+
   dimensions = {
     QueueName = aws_sqs_queue.dlq.name
   }
@@ -43,6 +45,8 @@ resource "aws_cloudwatch_metric_alarm" "queue_age" {
   period              = 60
   threshold           = local.max_age_in_seconds
   statistic           = "Maximum"
+
+  alarm_description = "Alarm if the age of the oldest message in the queue exceeds ${var.max_age_in_hours} hours"
 
   dimensions = {
     QueueName = aws_sqs_queue.q.name

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -1,5 +1,17 @@
+locals {
+  max_age_in_seconds = var.max_age_in_hours * 3600
+
+  # Allows for deprecation of alarm_topic_arn in favor of dlq_alarm_topic_arn
+  dlq_alarm_topic_arn = var.dlq_alarm_topic_arn != null ? var.dlq_alarm_topic_arn : var.alarm_topic_arn
+
+  # Name suffix allows for EventBridge rules to pick up alarms using wildcard
+  queue_age_alarm_name_suffix = var.queue_age_alarm_name_suffix != null ? "_${var.queue_age_alarm_name_suffix}" : ""
+  dlq_not_empty_alarm_name_suffix = var.dlq_not_empty_alarm_name_suffix != null ? "_${var.dlq_not_empty_alarm_name_suffix}" : ""
+}
+
+
 resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
-  count = var.alarm_topic_arn != null ? 1 : 0
+  count = local.dlq_alarm_topic_arn != null ? 1 : 0
 
   alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
   comparison_operator = "GreaterThanThreshold"
@@ -14,6 +26,24 @@ resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
     QueueName = aws_sqs_queue.dlq.name
   }
 
-  alarm_actions = [var.alarm_topic_arn]
+  alarm_actions = [local.dlq_alarm_topic_arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "queue_age" {
+  count = var.main_q_age_alarm_topic_arn != null ? 1 : 0
+
+  alarm_name          = "${aws_sqs_queue.q.name}_age${local.queue_age_alarm_name_suffix}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60
+  threshold           = local.max_age_in_seconds
+  statistic           = "Maximum"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.q.name
+  }
+
+  alarm_actions = [var.main_q_age_alarm_topic_arn]
+}

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -2,7 +2,8 @@ locals {
   max_age_in_seconds = var.max_age_in_hours * 3600
 
   # Allows for deprecation of alarm_topic_arn in favor of dlq_alarm_topic_arn
-  dlq_alarm_action_arns = var.dlq_alarm_action_arns != [] ? var.dlq_alarm_action_arns : [var.alarm_topic_arn]
+  alarm_topic_arn_safe = var.alarm_topic_arn != null ? [var.alarm_topic_arn] : []
+  dlq_alarm_action_arns = var.dlq_alarm_action_arns != [] ? var.dlq_alarm_action_arns : local.alarm_topic_arn_safe
 
   # Name suffix allows for EventBridge rules to pick up alarms using wildcard
   queue_age_alarm_name_suffix     = var.queue_age_alarm_name_suffix != null ? "_${var.queue_age_alarm_name_suffix}" : ""

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_age" {
   threshold           = local.max_age_in_seconds
   statistic           = "Maximum"
 
-  alarm_description = "Alarm if the age of the oldest message in the queue exceeds ${var.max_age_in_hours} hours"
+  alarm_description = "Message age exceeds ${var.max_age_in_hours} hours"
 
   dimensions = {
     QueueName = aws_sqs_queue.q.name

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
-  count = local.enable_dlq_not_empty_alarm ? 1 : 0
+  count = local.enable_dlq_not_empty_alarm == true ? 1 : 0
 
   alarm_name          = "${aws_sqs_queue.dlq.name}_not_empty"
   comparison_operator = "GreaterThanThreshold"
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_age" {
-  count = local.enable_queue_age_alarm ? 1 : 0
+  count = local.enable_queue_age_alarm == true ? 1 : 0
 
   alarm_name          = "${aws_sqs_queue.q.name}_age${local.queue_age_alarm_name_suffix}"
   comparison_operator = "GreaterThanThreshold"

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -10,7 +10,7 @@ locals {
   dlq_not_empty_alarm_name_suffix = var.dlq_not_empty_alarm_name_suffix != null ? "_${var.dlq_not_empty_alarm_name_suffix}" : ""
 
   enable_dlq_not_empty_alarm = var.enable_dlq_not_empty_alarm || local.dlq_alarm_action_arns != []
-  enable_queue_age_alarm     = var.enable_queue_age_alarm && var.main_q_age_alarm_action_arns != []
+  enable_queue_age_alarm     = var.enable_queue_age_alarm || var.main_q_age_alarm_action_arns != []
 }
 
 resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {

--- a/queue/alarms.tf
+++ b/queue/alarms.tf
@@ -5,10 +5,6 @@ locals {
   alarm_topic_arn_safe  = var.alarm_topic_arn != null ? [var.alarm_topic_arn] : []
   dlq_alarm_action_arns = var.dlq_alarm_action_arns != [] ? var.dlq_alarm_action_arns : local.alarm_topic_arn_safe
 
-  # Name suffix allows for EventBridge rules to pick up alarms using wildcard
-  queue_age_alarm_name_suffix     = var.queue_age_alarm_name_suffix != null ? "_${var.queue_age_alarm_name_suffix}" : ""
-  dlq_not_empty_alarm_name_suffix = var.dlq_not_empty_alarm_name_suffix != null ? "_${var.dlq_not_empty_alarm_name_suffix}" : ""
-
   enable_dlq_not_empty_alarm = var.enable_dlq_not_empty_alarm || local.dlq_alarm_action_arns != []
   enable_queue_age_alarm     = var.enable_queue_age_alarm || var.main_q_age_alarm_action_arns != []
 }
@@ -37,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_not_empty" {
 resource "aws_cloudwatch_metric_alarm" "queue_age" {
   count = local.enable_queue_age_alarm == true ? 1 : 0
 
-  alarm_name          = "${aws_sqs_queue.q.name}_age${local.queue_age_alarm_name_suffix}"
+  alarm_name          = "${aws_sqs_queue.q.name}_age"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateAgeOfOldestMessage"

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -43,7 +43,7 @@ variable "alarm_topic_arn" {
 }
 
 variable "enable_dlq_not_empty_alarm" {
-  description = "DEPRECATED, use dlq_alarm_topic_arn: Enable alarm for DLQ not being empty"
+  description = "Enable alarm for DLQs not being empty"
   default     = false
 }
 
@@ -53,12 +53,12 @@ variable "enable_queue_age_alarm" {
 }
 
 variable "dlq_alarm_action_arns" {
-  description = "ARNs for the topics where to send notification for DLQs not being empty. If null, no alarm will be created."
+  description = "ARNs for the topics where to send notification for DLQs not being empty, if not empty overrides alarm_topic_arn."
   default     = []
 }
 
 variable "main_q_age_alarm_action_arns" {
-  description = "ARN for the topics where to send notification for messages exceeding max_age_in_hours If null, no alarm will be created."
+  description = "ARN for the topics where to send notification for messages exceeding max_age_in_hours, if not empty overrides enable_queue_age_alarm."
   default     = []
 }
 

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -38,7 +38,33 @@ variable "max_receive_count" {
 }
 
 variable "alarm_topic_arn" {
+  description = "DEPRECATED, use dlq_alarm_topic_arn: ARN of the topic where to send notification for DLQs not being empty. If null, no alarm will be created."
+  default     = null
+}
+
+variable "dlq_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for DLQs not being empty. If null, no alarm will be created."
+  default     = null
+}
+
+variable "main_q_age_alarm_topic_arn" {
+  description = "ARN of the topic where to send notification for messages exceeding max_age_in_hours If null, no alarm will be created."
+  default     = null
+}
+
+variable "max_age_in_hours" {
+  description = "The maximum age of a message in hours"
+  type        = number
+  default     = 6
+}
+
+variable "queue_age_alarm_name_suffix" {
+  description = "Suffix to append to the queue name for the age alarm"
+  default     = null
+}
+
+variable "dlq_not_empty_alarm_name_suffix" {
+  description = "Suffix to append to the DLQ name for the not empty alarm"
   default     = null
 }
 

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -42,14 +42,24 @@ variable "alarm_topic_arn" {
   default     = null
 }
 
-variable "dlq_alarm_topic_arn" {
-  description = "ARN of the topic where to send notification for DLQs not being empty. If null, no alarm will be created."
-  default     = null
+variable "enable_dlq_not_empty_alarm" {
+  description = "DEPRECATED, use dlq_alarm_topic_arn: Enable alarm for DLQ not being empty"
+  default     = false
 }
 
-variable "main_q_age_alarm_topic_arn" {
-  description = "ARN of the topic where to send notification for messages exceeding max_age_in_hours If null, no alarm will be created."
-  default     = null
+variable "enable_queue_age_alarm" {
+  description = "Enable alarm for messages exceeding max_age_in_hours"
+  default     = false
+}
+
+variable "dlq_alarm_action_arns" {
+  description = "ARNs for the topics where to send notification for DLQs not being empty. If null, no alarm will be created."
+  default     = []
+}
+
+variable "main_q_age_alarm_action_arns" {
+  description = "ARN for the topics where to send notification for messages exceeding max_age_in_hours If null, no alarm will be created."
+  default     = []
 }
 
 variable "max_age_in_hours" {

--- a/queue/variables.tf
+++ b/queue/variables.tf
@@ -68,16 +68,6 @@ variable "max_age_in_hours" {
   default     = 6
 }
 
-variable "queue_age_alarm_name_suffix" {
-  description = "Suffix to append to the queue name for the age alarm"
-  default     = null
-}
-
-variable "dlq_not_empty_alarm_name_suffix" {
-  description = "Suffix to append to the DLQ name for the not empty alarm"
-  default     = null
-}
-
 variable "fifo_queue" {
   description = "Boolean designating a FIFO queue"
   default     = false


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/platform-infrastructure/pull/450.
Part of https://github.com/wellcomecollection/platform/issues/5809

This change adds alarms that alert for messages on the main queue that exceed a given age allowing us to create actions based on that state.

See [release notes for details.](https://github.com/wellcomecollection/terraform-aws-sqs/blob/max-age-alarm/RELEASE.md)

## How to test

- [ ] Include this module at the updated branch name in a consuming project, ensure it behaves as expected.

## How can we measure success?

Improved visibility of queues that have messages remaining unprocessed for a long time.

## Have we considered potential risks?

This will increase the potential volume of alerting, but hopefully should improve visbility rather than adding noise. This change is also backwards compatible with previous version in that it deprecates the `alarm_topic_arn` variable but still allows its use.
